### PR TITLE
Execute backup scripts in bash

### DIFF
--- a/templates/restic_access_Linux.j2
+++ b/templates/restic_access_Linux.j2
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # {{ ansible_managed }}
 # Backup credentials for {{ item.src|default('stdin') }}
 # Source this file to work with restic on this host

--- a/templates/restic_script_Linux.j2
+++ b/templates/restic_script_Linux.j2
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # {{ ansible_managed }}
 # Backup script for {{ item.src|default('stdin') }}
 # Use this file to create a Backup and prune existing data with one execution.


### PR DESCRIPTION
By default cron executes all entries using `sh` shell, this means `set -euxo pipefail` fails and the rest of the script is not executed.