### PR TITLE
Add AWS_DEFAULT_REGION variable and export S3 vars in scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Available variables:
 | `init`                  |    no    | Describes if the repository should be initialized or not. Use `false` if you are backuping to an already existing repo.                                                                                                                                                                                                 |
 | `aws_access_key`        |    no    | The access key for the S3 backend                                                                                                                                                                                                                                                                                       |
 | `aws_secret_access_key` |    no    | The secret access key for the S3 backend                                                                                                                                                                                                                                                                                                                        |
+| `aws_default_region` |    no    | The desired region for the S3 backend                                                                                                                                                                                                                                                                                                                        |
 
 Example:
 ```yaml

--- a/templates/restic_access_Linux.j2
+++ b/templates/restic_access_Linux.j2
@@ -11,6 +11,9 @@ AWS_ACCESS_KEY_ID={{ restic_repos[item.repo].aws_access_key }}
 {% if restic_repos[item.repo].aws_secret_access_key is defined %}
 AWS_SECRET_ACCESS_KEY={{ restic_repos[item.repo].aws_secret_access_key }}
 {% endif %}
+{% if restic_repos[item.repo].aws_default_region is defined %}
+AWS_DEFAULT_REGION={{ restic_repos[item.repo].aws_default_region }}
+{% endif %}
 BACKUP_NAME={{ item.name }}
 {% if item.src is defined %}
 BACKUP_SOURCE={{ item.src }}

--- a/templates/restic_access_Linux.j2
+++ b/templates/restic_access_Linux.j2
@@ -6,13 +6,13 @@
 export RESTIC_REPOSITORY={{ restic_repos[item.repo].location }}
 export RESTIC_PASSWORD={{ restic_repos[item.repo].password }}
 {% if restic_repos[item.repo].aws_access_key is defined %}
-AWS_ACCESS_KEY_ID={{ restic_repos[item.repo].aws_access_key }}
+export AWS_ACCESS_KEY_ID={{ restic_repos[item.repo].aws_access_key }}
 {% endif %}
 {% if restic_repos[item.repo].aws_secret_access_key is defined %}
-AWS_SECRET_ACCESS_KEY={{ restic_repos[item.repo].aws_secret_access_key }}
+export AWS_SECRET_ACCESS_KEY={{ restic_repos[item.repo].aws_secret_access_key }}
 {% endif %}
 {% if restic_repos[item.repo].aws_default_region is defined %}
-AWS_DEFAULT_REGION={{ restic_repos[item.repo].aws_default_region }}
+export AWS_DEFAULT_REGION={{ restic_repos[item.repo].aws_default_region }}
 {% endif %}
 BACKUP_NAME={{ item.name }}
 {% if item.src is defined %}

--- a/templates/restic_script_Linux.j2
+++ b/templates/restic_script_Linux.j2
@@ -7,13 +7,13 @@ export RESTIC_REPOSITORY={{ restic_repos[item.repo].location }}
 export RESTIC_PASSWORD={{ restic_repos[item.repo].password }}
 BACKUP_NAME={{ item.name }}
 {% if restic_repos[item.repo].aws_access_key is defined %}
-AWS_ACCESS_KEY_ID={{ restic_repos[item.repo].aws_access_key }}
+export AWS_ACCESS_KEY_ID={{ restic_repos[item.repo].aws_access_key }}
 {% endif %}
 {% if restic_repos[item.repo].aws_secret_access_key is defined %}
-AWS_SECRET_ACCESS_KEY={{ restic_repos[item.repo].aws_secret_access_key }}
+export AWS_SECRET_ACCESS_KEY={{ restic_repos[item.repo].aws_secret_access_key }}
 {% endif %}
 {% if restic_repos[item.repo].aws_default_region is defined %}
-AWS_DEFAULT_REGION={{ restic_repos[item.repo].aws_default_region }}
+export AWS_DEFAULT_REGION={{ restic_repos[item.repo].aws_default_region }}
 {% endif %}
 {% if item.src is defined %}
 BACKUP_SOURCE={{ item.src }}

--- a/templates/restic_script_Linux.j2
+++ b/templates/restic_script_Linux.j2
@@ -12,6 +12,9 @@ AWS_ACCESS_KEY_ID={{ restic_repos[item.repo].aws_access_key }}
 {% if restic_repos[item.repo].aws_secret_access_key is defined %}
 AWS_SECRET_ACCESS_KEY={{ restic_repos[item.repo].aws_secret_access_key }}
 {% endif %}
+{% if restic_repos[item.repo].aws_default_region is defined %}
+AWS_DEFAULT_REGION={{ restic_repos[item.repo].aws_default_region }}
+{% endif %}
 {% if item.src is defined %}
 BACKUP_SOURCE={{ item.src }}
 {% endif %}


### PR DESCRIPTION
An environment variable that allows setting the default region to use was [added](https://github.com/restic/restic/pull/2484) to Restic last November.

This var has to be used for some S3 providers such as Scaleway.

I've added it to the template files.

While setting up my own backups, I also noticed the script hanged if the AWS_* vars weren't exported. I've corrected that as well.