### PR TITLE
Add the possibility to exclude certain files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 and [human-readable changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Added
+* Config option to exclude files
 
 ## [0.2.6] 2020-06-05
 ### Changed

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ exclude:
         - /path/to/file
 ```
 Please refer to the use of the specific keys to the
-[documentation](https://restic.readthedocs.io/en/latest/040_backup.html#excluding-files ).
+[documentation](https://restic.readthedocs.io/en/latest/040_backup.html#excluding-files).
 
 ## Dependencies
 none

--- a/README.md
+++ b/README.md
@@ -136,6 +136,25 @@ Available variables:
 | `schedule_hour`    |           no (`*`)            | Hour when the job is run. ( 0-23, *, */2, etc )                                                                                                                              |
 | `schedule_weekday` |           no (`*`)            | Weekday when the job is run.  ( 0-6 for Sunday-Saturday, *, etc )                                                                                                            |
 | `schedule_month`   |           no (`*`)            | Month when the job is run. ( 1-12, *, */2, etc )                                                                                                                             |
+| `exclude`          |           no (`{}`)           | Allows you to specify files to exclude. See [Exclude](#exclude) for reference.                                                                                               |
+
+#### Exclude
+the `exclude` key on a backup allows you to specify multiple files to exclude or
+files to look for filenames to be excluded. You can specify the following keys:
+```yaml
+exclude:
+    exclude_cache: true
+    exclude:
+        - /path/to/file
+    iexclude:
+        - /path/to/file
+    exclude_file:
+        - /path/to/file
+    exclude_if_present:
+        - /path/to/file
+```
+Please refer to the use of the specific keys to the
+[documentation](https://restic.readthedocs.io/en/latest/040_backup.html#excluding-files ).
 
 ## Dependencies
 none

--- a/templates/restic_script_Linux.j2
+++ b/templates/restic_script_Linux.j2
@@ -97,7 +97,12 @@ else
   MODE_TAG="--tag cron"
 fi
 {% if item.stdin is defined and item.stdin == true %}
-  {{ item.stdin_cmd }} | {{ restic_install_path }}/restic backup --stdin $MODE_TAG {{ tags(item.tags) }} {{ stdin_filename(item.stdin_filename) }} $@
+  {{ item.stdin_cmd }} | {{ restic_install_path }}/restic backup \
+    --stdin $MODE_TAG \
+    {{ tags(item.tags) }} \
+    {{ stdin_filename(item.stdin_filename) }} \
+    {% if item.exclude is defined %}{{ exclude(item.exclude) }}{% endif %} \
+    $@
 {% else %}
   {{ restic_install_path }}/restic backup $BACKUP_SOURCE $MODE_TAG \
     {{ tags(item.tags) }} \

--- a/templates/restic_script_Linux.j2
+++ b/templates/restic_script_Linux.j2
@@ -62,6 +62,32 @@ set -euxo pipefail
   {% if repo.keep_within is defined and repo.keep_within != None %}--keep-within {{ item.keep_within }}{% endif %} \
   {% if repo.keep_tag is defined and (repo.keep_tag|length>0) %}{{ keep_tags(repo.keep_tag) }}{% endif %}
 {%- endmacro %}
+
+{% macro exclude(exclude) %}
+    {% if exclude.exclude_cache is defined and exclude.exclude_cache == true %}
+        --exclude-cache \
+    {% endif %}
+    {% if exclude.exclude is defined %}
+        {% for path in exclude.exclude %}
+            --exclude {{ path }} \
+        {% endfor %}
+    {% endif %}
+    {% if exclude.iexclude is defined %}
+        {% for path in exclude.iexclude %}
+            --iexclude {{ path }} \
+        {% endfor %}
+    {% endif %}
+    {% if exclude.exclude_file is defined %}
+        {% for path in exclude.exclude_file %}
+            --exclude-file {{ path }} \
+        {% endfor %}
+    {% endif %}
+    {% if exclude.exclude_if_present is defined %}
+        {% for path in exclude.exclude_if_present %}
+            --exclude-if-present {{ path }} \
+        {% endfor %}
+    {% endif %}
+{% endmacro %}
 {#
   Define backup commands
 #}
@@ -73,7 +99,10 @@ fi
 {% if item.stdin is defined and item.stdin == true %}
   {{ item.stdin_cmd }} | {{ restic_install_path }}/restic backup --stdin $MODE_TAG {{ tags(item.tags) }} {{ stdin_filename(item.stdin_filename) }} $@
 {% else %}
-  {{ restic_install_path }}/restic backup $BACKUP_SOURCE $MODE_TAG {{ tags(item.tags) }} $@
+  {{ restic_install_path }}/restic backup $BACKUP_SOURCE $MODE_TAG \
+    {{ tags(item.tags) }} \
+    {% if item.exclude is defined %}{{ exclude(item.exclude) }}{% endif %} \
+    $@
 {% endif %}
 {#
   Define stdin forget commands


### PR DESCRIPTION
Add the `--exclude*` options (https://restic.readthedocs.io/en/latest/040_backup.html#excluding-files) to the generated backup script. Closes #12 