### PR TITLE
ADD: Check that restic has been installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 and [human-readable changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Added
+* Sanity check for restic binary
+
 ## [0.2.7] 2020-08-05
 ### Added
 * Config option to exclude files

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -20,7 +20,7 @@
     mode: '0755'
     owner: '{{ restic_dir_owner }}'
     group: '{{ restic_dir_group }}'
-    
+
 - name: Test the binary
   shell: "{{ restic_bin_bath }} version"
   ignore_errors: true
@@ -31,11 +31,12 @@
     path: '{{ restic_bin_bath }}'
     state: absent
   when: "'FAILED' in restic_test_result.stderr"
-  
 
 - name: Fail if restic could not be installed
   fail:
-    msg: "Restic binary has been faulty and has been removed. Try to re-run the role and make sure you have bzip2 installed!"
+    msg: | -1
+      Restic binary has been faulty and has been removed.
+      Try to re-run the role and make sure you have bzip2 installed!
   when: "'FAILED' in restic_test_result.stderr"
 
 - name: Create symbolic link to the correct version

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -34,7 +34,7 @@
 
 - name: Fail if restic could not be installed
   fail:
-    msg: | -1
+    msg: >-
       Restic binary has been faulty and has been removed.
       Try to re-run the role and make sure you have bzip2 installed!
   when: "'FAILED' in restic_test_result.stderr"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -20,6 +20,23 @@
     mode: '0755'
     owner: '{{ restic_dir_owner }}'
     group: '{{ restic_dir_group }}'
+    
+- name: Test the binary
+  shell: "{{ restic_bin_bath }} version"
+  ignore_errors: true
+  register: restic_test_result
+
+- name: Remove faulty binary
+  file:
+    path: '{{ restic_bin_bath }}'
+    state: absent
+  when: "'FAILED' in restic_test_result.stderr"
+  
+
+- name: Fail if restic could not be installed
+  fail:
+    msg: "Restic binary has been faulty and has been removed. Try to re-run the role and make sure you have bzip2 installed!"
+  when: "'FAILED' in restic_test_result.stderr"
 
 - name: Create symbolic link to the correct version
   file:


### PR DESCRIPTION
Adds a check to test the downloaded and extracted binary to be executable and remove it in case it is not.

Closes #15 