### PR TITLE
add: auto restore option for backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,18 @@ simply appending them:
 $ /path/to/backup/script/backup-example.sh --tag deployment
 ```
 
+### Access scripts
+```bash
+. /path/to/backup/script/access-example.sh
+restic snapshots
+```
+
+### Restore scripts
+```bash
+# This will restore the latest backup
+/path/to/backup/script/restore-example.sh
+```
+
 ### CRON / Scheduled Tasks
 In order to make use of defined backups, they can be automatically setup as
 scheduled tasks. You have to be aware of the fact that (on linux systems at
@@ -105,6 +117,7 @@ restic_repos:
     location: sftp:user@host:/srv/restic-repo
     password: securepassword2
     init: true
+
 ```
 
 ### Backups
@@ -118,6 +131,7 @@ Available variables:
 | `name`             |              yes              | The name of this backup. Used together with pruning and scheduling and needs to be unique.                                                                                   |
 | `repo`             |              yes              | The name of the repository to backup to.                                                                                                                                     |
 | `src`              |              yes              | The source directory or file                                                                                                                                                 |
+| `auto_restore`     |              no               | This will auto restore the latest backup in the event that a state file does not exist in /var/restic-auto-restore                                                           |
 | `stdin`            |              no               | Is this backup created from a [stdin](https://restic.readthedocs.io/en/stable/040_backup.html#reading-data-from-stdin)?                                                      |
 | `stdin_cmd`        | no (yes if `stdin` == `true`) | The command to produce the stdin.                                                                                                                                            |
 | `stdin_filename`   |              no               | The filename used in the repository.                                                                                                                                         |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,5 +9,7 @@ restic_repos: {}
 restic_backups: []
 restic_create_cron: false
 
+restic_auto_restore_dir: /var/restic-auto-restore
+
 restic_dir_owner: '{{ ansible_user | default(ansible_user_id) }}'
 restic_dir_group: '{{ ansible_user | default(ansible_user_id) }}'

--- a/tasks/distribution/Linux.yml
+++ b/tasks/distribution/Linux.yml
@@ -63,15 +63,13 @@
     - item.scheduled | default(false)
   with_items: '{{ restic_backups }}'
 
-- name: "restic auto_restore"
+- name: restic auto_restore
   include: restic_auto_restore.yml
   when:
-    - item.name is defined
-    - item.src is defined or item.stdin is defined
-    - item.src is defined or item.stdin and item.stdin_cmd is defined
-    - item.repo in restic_repos
-  with_items: "{{ restic_backups }}"
+    - restic_backups_loop.name is defined
+    - restic_backups_loop.src is defined or restic_backups_loop.stdin is defined
+    - restic_backups_loop.src is defined or restic_backups_loop.stdin and restic_backups_loop.stdin_cmd is defined
+    - restic_backups_loop.repo in restic_repos
+  loop: "{{ restic_backups }}"
   loop_control:
-    loop_var: "{{ item.name }}"
-
-
+    loop_var: restic_backups_loop

--- a/tasks/distribution/Linux.yml
+++ b/tasks/distribution/Linux.yml
@@ -31,6 +31,21 @@
     - item.src is defined or item.stdin and item.stdin_cmd is defined
     - item.repo in restic_repos
 
+- name: Create restore script
+  template:
+    src: restic_restore_Linux.j2
+    dest: '{{ restic_script_dir }}/restore-{{ item.name }}.sh'
+    mode: '0700'
+    owner: '{{ restic_dir_owner }}'
+    group: '{{ restic_dir_group }}'
+  no_log: true
+  with_items: '{{ restic_backups }}'
+  when:
+    - item.name is defined
+    - item.src is defined or item.stdin is defined
+    - item.src is defined or item.stdin and item.stdin_cmd is defined
+    - item.repo in restic_repos
+
 - name: Setup CRON jobs
   cron:
     name: 'arillso.restic backup {{ item.name }}'
@@ -47,3 +62,15 @@
     - item.name is defined
     - item.scheduled | default(false)
   with_items: '{{ restic_backups }}'
+
+- include: restic_auto_restore.yml
+  with_items: "{{ restic_backups }}"
+  when:
+    - item.name is defined
+    - item.src is defined or item.stdin is defined
+    - item.src is defined or item.stdin and item.stdin_cmd is defined
+    - item.repo in restic_repos
+  loop_control:
+    loop_var: restic_backups_loop
+
+

--- a/tasks/distribution/Linux.yml
+++ b/tasks/distribution/Linux.yml
@@ -63,14 +63,15 @@
     - item.scheduled | default(false)
   with_items: '{{ restic_backups }}'
 
-- include: restic_auto_restore.yml
-  with_items: "{{ restic_backups }}"
+- name: "restic auto_restore"
+  include: restic_auto_restore.yml
   when:
     - item.name is defined
     - item.src is defined or item.stdin is defined
     - item.src is defined or item.stdin and item.stdin_cmd is defined
     - item.repo in restic_repos
+  with_items: "{{ restic_backups }}"
   loop_control:
-    loop_var: restic_backups_loop
+    loop_var: "{{ item.name }}"
 
 

--- a/tasks/distribution/restic_auto_restore.yml
+++ b/tasks/distribution/restic_auto_restore.yml
@@ -7,5 +7,3 @@
 - name: "run restore if {{ restic_auto_restore_dir }}/{{ restic_backups_loop.name }}.state and auto restore is set"
   shell: "{{ restic_script_dir }}/restore-{{ restic_backups_loop.name }}.sh && touch {{ restic_auto_restore_dir }}/{{ restic_backups_loop.name }}.state"
   when: not restic_restore_state_file.stat.exists and restic_backups_loop.auto_restore is defined
-
-

--- a/tasks/distribution/restic_auto_restore.yml
+++ b/tasks/distribution/restic_auto_restore.yml
@@ -1,0 +1,11 @@
+- name: "check for a state file {{ restic_auto_restore_dir }}/{{ restic_backups_loop.name }}.state"
+  stat:
+    path: "{{ restic_auto_restore_dir }}/{{ restic_backups_loop.name }}.state"
+  register: restic_restore_state_file
+  when: restic_backups_loop.auto_restore is defined
+
+- name: "run restore if {{ restic_auto_restore_dir }}/{{ restic_backups_loop.name }}.state and auto restore is set"
+  shell: "{{ restic_script_dir }}/restore-{{ restic_backups_loop.name }}.sh && touch {{ restic_auto_restore_dir }}/{{ restic_backups_loop.name }}.state"
+  when: not restic_restore_state_file.stat.exists and restic_backups_loop.auto_restore is defined
+
+

--- a/tasks/distribution/restic_auto_restore.yml
+++ b/tasks/distribution/restic_auto_restore.yml
@@ -1,9 +1,25 @@
+# - name: auto_restore check
+#   debug:
+#     msg: "auto_restore in? {{ restic_backups_loop }}"
+
+# - name: auto_restore enabled
+#   debug:
+#     msg: "auto_restore enabled {{ restic_backups_loop }}"
+#   when: restic_backups_loop.auto_restore is defined
+
 - name: "check for a state file {{ restic_auto_restore_dir }}/{{ restic_backups_loop.name }}.state"
   stat:
     path: "{{ restic_auto_restore_dir }}/{{ restic_backups_loop.name }}.state"
   register: restic_restore_state_file
   when: restic_backups_loop.auto_restore is defined
 
+# - name: auto_restore stat
+#   debug:
+#     msg: "auto_restore stat results {{ restic_restore_state_file }}"
+#   when: restic_restore_state_file is defined
+
 - name: "run restore if {{ restic_auto_restore_dir }}/{{ restic_backups_loop.name }}.state and auto restore is set"
   shell: "{{ restic_script_dir }}/restore-{{ restic_backups_loop.name }}.sh && touch {{ restic_auto_restore_dir }}/{{ restic_backups_loop.name }}.state"
-  when: not restic_restore_state_file.stat.exists and restic_backups_loop.auto_restore is defined
+  when:
+    - restic_backups_loop.auto_restore is defined
+    - not restic_restore_state_file.stat.exists

--- a/templates/restic_restore_Linux.j2
+++ b/templates/restic_restore_Linux.j2
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# {{ ansible_managed }}
+# Restore script for {{ item.src|default('stdin') }}
+# Use this file to restore a latest Backup with one execution.
+
+export RESTIC_REPOSITORY={{ restic_repos[item.repo].location }}
+export RESTIC_PASSWORD={{ restic_repos[item.repo].password }}
+BACKUP_NAME={{ item.name }}
+{% if restic_repos[item.repo].aws_access_key is defined %}
+export AWS_ACCESS_KEY_ID={{ restic_repos[item.repo].aws_access_key }}
+{% endif %}
+{% if restic_repos[item.repo].aws_secret_access_key is defined %}
+export AWS_SECRET_ACCESS_KEY={{ restic_repos[item.repo].aws_secret_access_key }}
+{% endif %}
+{% if restic_repos[item.repo].aws_default_region is defined %}
+export AWS_DEFAULT_REGION={{ restic_repos[item.repo].aws_default_region }}
+{% endif %}
+{% if item.src is defined %}
+BACKUP_SOURCE={{ item.src }}
+{% endif %}
+set -euxo pipefail
+
+restic restore latest --target $BACKUP_SOURCE
+

--- a/templates/restic_restore_Linux.j2
+++ b/templates/restic_restore_Linux.j2
@@ -20,5 +20,4 @@ BACKUP_SOURCE={{ item.src }}
 {% endif %}
 set -euxo pipefail
 
-restic restore latest --target $BACKUP_SOURCE
-
+restic restore latest --target /

--- a/vars/defaults.yml
+++ b/vars/defaults.yml
@@ -10,6 +10,7 @@ _platform_map:
 restic_create_paths:
   - '{{ restic_download_path }}/bin'
   - '{{ restic_script_dir }}'
+  - '{{ restic_auto_restore_dir }}'
 
 restic_bin_bath: '{{ restic_download_path }}/bin/restic-{{ restic_version }}'
 


### PR DESCRIPTION
https://github.com/arillso/ansible.restic/pull/13/commits/1b0655d112a7e0018704c61fab6defd6350344ff

I pulled out the auto restore options from gilesw's PR https://github.com/arillso/ansible.restic/pull/13

I tried to stay within similar style as the current role but was still heavily learning Ansible so feel free to suggest improvements.

One area I'm concerned about is always restoring to / - I believe this is the right behavior but would like a 2nd set of eyes.

When I allowed the restore script to restore to $BACKUP_SOURCE, my src directory of /home/homeassistant was restored to /home/homeassistant/home/homeassistant.