### PR TITLE
change: backups can be defined as dicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,12 +65,12 @@ ansible-galaxy install arillso.restic
 | Name                   | Default              | Description                                                                 |
 | ---------------------- | -------------------- | --------------------------------------------------------------------------- |
 | `restic_url`           | `undefined`          | The URL to download restic from. Use this variable to overwrite the default |
-| `restic_version`       | `'0.11.0'`            | The version of Restic to install                                            |
+| `restic_version`       | `'0.11.0'`           | The version of Restic to install                                            |
 | `restic_download_path` | `'/opt/restic'`      | Download location for the restic binary                                     |
 | `restic_install_path`  | `'/usr/local/bin'`   | Install location for the restic binary                                      |
 | `restic_script_dir`    | `'~/restic'`         | Location of the generated backup scripts                                    |
 | `restic_repos`         | `{}`                 | A dictionary of repositories where snapshots are stored                     |
-| `restic_backups`       | `[]`                 | A list of dictionaries specifying the files and directories to be backed up |
+| `restic_backups`       | `{}` (or `[]`)       | A list of dictionaries specifying the files and directories to be backed up |
 | `restic_create_cron`   | `false`              | Should a cronjob be created for each backup                                 |
 | `restic_dir_owner`     | `'{{ansible_user}}'` | The owner of all created dirs                                               |
 | `restic_dir_group`     | `'{{ansible_user}}'` | The group of all created dirs                                               |
@@ -146,12 +146,17 @@ Available variables:
 Example:
 ```yaml
 restic_backups:
-  - name: data
+  data:
+    name: data
     repo: remove
     src: /path/to/data
     scheduled: true
     schedule_hour: 3
 ```
+
+> You can also specify restic_backups as an array, which is a legacy feature and
+> might be deprecated in the future. currently, the name key is used for
+> namint the access and backup files
 
 #### Exclude
 the `exclude` key on a backup allows you to specify multiple files to exclude or

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -32,3 +32,28 @@
         keep_daily: 7
         keep_monthly: 12
         keep_yearly: 5
+
+- name: Converge with dict
+  hosts: all
+  roles:
+    - role: ansible.restic
+  pre_tasks:
+    - name: install bzip2
+      package:
+        name: bzip2
+        state: present
+  vars:
+    restic_download_path: ~/restic
+    restic_install_path: ~/restic
+    restic_repos:
+      local:
+        location: /backup
+        password: securepassword1
+        init: true
+    restic_backups:
+      dicttest:
+        name: dicttest
+        src: /home
+        repo: local
+        keep_last: 4
+        keep_tag: deployment

--- a/molecule/default/test_restic/tasks/test_backup_files.yml
+++ b/molecule/default/test_restic/tasks/test_backup_files.yml
@@ -22,5 +22,6 @@
     args:
       chdir: ~/restic/
     with_items:
+      - backup-dicttest.sh
       - backup-test.sh
       - backup-test_stdin.sh

--- a/tasks/distribution/Linux.yml
+++ b/tasks/distribution/Linux.yml
@@ -9,7 +9,9 @@
     owner: '{{ restic_dir_owner }}'
     group: '{{ restic_dir_group }}'
   no_log: true
-  with_items: '{{ restic_backups | dict2items }}'
+  loop: "{{ items|flatten(levels=1) }}"
+  loop_control:
+    index_var: index
   when:
     - item.name is defined
     - item.src is defined or item.stdin is defined
@@ -24,7 +26,9 @@
     owner: '{{ restic_dir_owner }}'
     group: '{{ restic_dir_group }}'
   no_log: true
-  with_items: '{{ restic_backups | dict2items }}'
+  loop: "{{ items|flatten(levels=1) }}"
+  loop_control:
+    index_var: index
   when:
     - item.name is defined
     - item.src is defined or item.stdin is defined
@@ -46,4 +50,6 @@
     - restic_create_cron
     - item.name is defined
     - item.scheduled | default(false)
-  with_items: '{{ restic_backups | dict2items }}'
+  loop: "{{ items|flatten(levels=1) }}"
+  loop_control:
+    index_var: index

--- a/tasks/distribution/Linux.yml
+++ b/tasks/distribution/Linux.yml
@@ -1,7 +1,7 @@
 ---
 # tasks file for skeleton
 
-- name: reformat dict if necessary:
+- name: reformat dict if necessary
   set_fact:
     restic_backups: "{{ restic_backups|dict2items|json_query('[*].value') }}"
   when:

--- a/tasks/distribution/Linux.yml
+++ b/tasks/distribution/Linux.yml
@@ -4,8 +4,8 @@
 - name: reformat dict if necessary:
   set_fact:
     restic_backups: "{{ restic_backups|dict2items|json_query('[*].value') }}"
-    when:
-      mydict | restic_backups == "dict"
+  when:
+    - restic_backups | type_debug == "dict"
 
 - name: Create backup credentials
   template:

--- a/tasks/distribution/Linux.yml
+++ b/tasks/distribution/Linux.yml
@@ -9,7 +9,7 @@
     owner: '{{ restic_dir_owner }}'
     group: '{{ restic_dir_group }}'
   no_log: true
-  with_items: '{{ restic_backups }}'
+  with_items: '{{ restic_backups | dict2items }}'
   when:
     - item.name is defined
     - item.src is defined or item.stdin is defined
@@ -24,7 +24,7 @@
     owner: '{{ restic_dir_owner }}'
     group: '{{ restic_dir_group }}'
   no_log: true
-  with_items: '{{ restic_backups }}'
+  with_items: '{{ restic_backups | dict2items }}'
   when:
     - item.name is defined
     - item.src is defined or item.stdin is defined
@@ -46,4 +46,4 @@
     - restic_create_cron
     - item.name is defined
     - item.scheduled | default(false)
-  with_items: '{{ restic_backups }}'
+  with_items: '{{ restic_backups | dict2items }}'

--- a/tasks/distribution/Linux.yml
+++ b/tasks/distribution/Linux.yml
@@ -9,7 +9,7 @@
     owner: '{{ restic_dir_owner }}'
     group: '{{ restic_dir_group }}'
   no_log: true
-  loop: "{{ items|flatten(levels=1) }}"
+  loop: "{{ items|items2dict|flatten(levels=1) }}"
   loop_control:
     index_var: index
   when:
@@ -26,7 +26,7 @@
     owner: '{{ restic_dir_owner }}'
     group: '{{ restic_dir_group }}'
   no_log: true
-  loop: "{{ items|flatten(levels=1) }}"
+  loop: "{{ items|items2dict|flatten(levels=1) }}"
   loop_control:
     index_var: index
   when:
@@ -46,7 +46,7 @@
     state: present
   become: true
   no_log: true
-  loop: "{{ items|flatten(levels=1) }}"
+  loop: "{{ items|items2dict|flatten(levels=1) }}"
   loop_control:
     index_var: index
   when:

--- a/tasks/distribution/Linux.yml
+++ b/tasks/distribution/Linux.yml
@@ -1,6 +1,12 @@
 ---
 # tasks file for skeleton
 
+- name: reformat dict if necessary:
+  set_fact:
+    restic_backups: "{{ restic_backups|dict2items|json_query('[*].value') }}"
+    when:
+      mydict | restic_backups == "dict"
+
 - name: Create backup credentials
   template:
     src: restic_access_Linux.j2
@@ -9,9 +15,7 @@
     owner: '{{ restic_dir_owner }}'
     group: '{{ restic_dir_group }}'
   no_log: true
-  loop: "{{ items|items2dict|flatten(levels=1) }}"
-  loop_control:
-    index_var: index
+  with_items: '{{ restic_backups }}'
   when:
     - item.name is defined
     - item.src is defined or item.stdin is defined
@@ -26,9 +30,7 @@
     owner: '{{ restic_dir_owner }}'
     group: '{{ restic_dir_group }}'
   no_log: true
-  loop: "{{ items|items2dict|flatten(levels=1) }}"
-  loop_control:
-    index_var: index
+  with_items: '{{ restic_backups }}'
   when:
     - item.name is defined
     - item.src is defined or item.stdin is defined
@@ -46,9 +48,7 @@
     state: present
   become: true
   no_log: true
-  loop: "{{ items|items2dict|flatten(levels=1) }}"
-  loop_control:
-    index_var: index
+  with_items: '{{ restic_backups }}'
   when:
     - restic_create_cron
     - item.name is defined

--- a/tasks/distribution/Linux.yml
+++ b/tasks/distribution/Linux.yml
@@ -46,10 +46,10 @@
     state: present
   become: true
   no_log: true
+  loop: "{{ items|flatten(levels=1) }}"
+  loop_control:
+    index_var: index
   when:
     - restic_create_cron
     - item.name is defined
     - item.scheduled | default(false)
-  loop: "{{ items|flatten(levels=1) }}"
-  loop_control:
-    index_var: index


### PR DESCRIPTION
This PR allows to define the backups as a dict instead of an array. This makes definition more intuitive, as it follows the notation used to define the repositories. In order to maintain backwards compatibility, arrays are still allowed and the `name` field of the backup definition is taken as actual name