### PR TITLE
Replace include by include_tasks

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,11 +43,11 @@
   register: restic_installed
 
 - name: Install restic
-  include: 'install.yml'
+  include_tasks: 'install.yml'
   when: not restic_executable.stat.exists or not restic_installed.stat.exists
 
 - name: Configure restic
-  include: 'configure.yml'
+  include_tasks: 'configure.yml'
 
 - name: include distribution tasks
   include_tasks: '{{ loop_distribution }}'


### PR DESCRIPTION
Fixing the deprecation warning below.
[DEPRECATION WARNING]: "include" is deprecated, use include_tasks/import_tasks instead. This feature will be removed in version 2.16.